### PR TITLE
Reference section updates

### DIFF
--- a/src/doc/reference/creating-elements.md
+++ b/src/doc/reference/creating-elements.md
@@ -7,7 +7,7 @@
 
 # Creating elements
 
-Creating a new HTML element is easy with Bosonic. Here is a boilerplate of a basic element (let's say you'll save this as `lib/hello-world.html`):
+Creating a new HTML element is easy with Bosonic. Here is a boilerplate of a basic element (let's assume for now that you'll save this as `lib/hello-world.html`):
 
 ``` html
 <element name="hello-world">
@@ -25,11 +25,11 @@ Creating a new HTML element is easy with Bosonic. Here is a boilerplate of a bas
 </element>
 ```
 
-As you can see, the `<element>` tag that encapsulates our element's definition has a `name` attribute: it is of course mandatory, as it specifies the name of the HTML tag you’ll instantiate in markup. Per spec, it __must__ contain a "-".
+As you can see, the `<element>` tag that encapsulates our element's definition has a `name` attribute: it is of course mandatory, as it specifies the name of the HTML tag you’ll instantiate in the markup. As per spec, it __must__ contain a "-".
 
 In the `<script>` element, we call `Bosonic.register` to register the API of our new element: all methods & properties defined here will become API methods & props of each attached element in a web page.
 
-One of the Bosonic's features is the automatic rendering of the `<template>` tag content: this markup will become our elements' [Shadow DOM](http://webcomponents.org/polyfills/shadow-dom/). The `shadowRoot` property allows you to query and manipulate this Shadow DOM, as showed in the `sayHello` method.
+One of the Bosonic's features is the automatic rendering of the `<template>` tag content: this markup will become our elements' [Shadow DOM](http://webcomponents.org/polyfills/shadow-dom/). The `shadowRoot` property allows you to query and manipulate this Shadow DOM, as shown in the `sayHello` method.
 
 Using our new element in a web page is easy too:
 

--- a/src/doc/reference/introduction.md
+++ b/src/doc/reference/introduction.md
@@ -7,11 +7,11 @@
 
 # Introduction
 
-If you already digested the "Getting started" section, you probably doesn't need to read this. 
+If you've already read the "Getting started" section, you probably doesn't need to read this.
 
-Why? Because __Bosonic aims to be a library of low-level UI elements__, elements that you can just drop into your project and use immediately. This is a major problem in Web Components' evangelization by the way: a lot of people I've talked to think that Web Components are a stack of technologies designed for building components & complete apps as HTML elements, but that's not the case, at least in my mind. Web Components enable the creation of __UI atoms__ as HTML elements, atoms that you can include into your components templates, powered by Angular, Ember, React or whatever.
+Why? Because __Bosonic aims to be a library of low-level UI elements__, elements that you can just drop into your project and use immediately. This is a major problem in Web Components' evangelization by the way: a lot of people I've talked to think that Web Components are a stack of technologies designed for building components & complete apps as HTML elements, but that's not the case, at least not in my mind. Web Components enable the creation of __UI atoms__ as HTML elements, atoms that you can include into your components templates, powered by Angular, Ember, React or whatever.
 
-Did you ever use Bootstrap? How did you use it? You included some files, copied&pasted some markup, and you got a nice UI component in your app. It's the same with Bosonic, minus the copy&paste thing. Like Bootstrap, we want to provide you with common, everyday-use UI behaviours and styling nicely wrapped in custom HTML elements. Of course, as vanilla Web Components tend to be a bit verbose, we built a small library (our so-called runtime) that eases the burden of building our elements, and this is what we documented in this section.
+Have you ever use Bootstrap? How did you use it? You included some files, copied&pasted some markup, and you got a nice UI component in your app. It's the same with Bosonic, minus the copy&paste thing. Like Bootstrap, we want to provide you with common, everyday UI behaviours and styling nicely wrapped in custom HTML elements. Of course, as vanilla Web Components tend to be a bit verbose, we built a small library (our so-called runtime) that eases the burden of building our elements, and this is what we documented in this section.
 
 But, if you came here with the intent of building your own elements, think twice: is your planned element really generic, low-level and reusable in all your apps? Could it make its way into the Bosonic elements catalogue (if you think so, drop us a note about it)? Do you feel it would make a nice addition to the HTML native elements? If that's the case, please read on.
 

--- a/src/doc/reference/lifecycle-callbacks.md
+++ b/src/doc/reference/lifecycle-callbacks.md
@@ -14,7 +14,7 @@ Lifecycle callbacks are special methods defined by the Custom Elements specifica
 - `detachedCallback()` is called when a custom element is removed from a DOM subtree.
 - `attributeChangedCallback(attributeName, oldValue, newValue)` is called when a custom element's attribute value has changed.
 
-Bosonic provides an useful feature: if you declare the attributes used by your element in the `<element>` tag, like this:
+Bosonic provides a useful feature: if you declare the attributes used by your element in the `<element>` tag, like this:
 ``` html
 <element name="hello-world" attributes="opened active">
     ...

--- a/src/doc/reference/shadow-css.md
+++ b/src/doc/reference/shadow-css.md
@@ -11,7 +11,7 @@ Shadow DOM is designed for CSS scoping & encapsulation. As such, styling Shadow 
 
 Please note that Shadow DOM spec is still a draft, and so CSS rules may change. We'll try to keep Bosonic in sync with these potential changes.
 
-Keep in mind that some of these rules are not easily shimable, therefore Bosonic support of these rules is limited. To be on the safe side, use only rules that are documented here.
+Keep in mind that some of these rules are not easily shimmed, therefore Bosonic support of these rules is limited. To be on the safe side, use only rules that are documented here.
 
 ### Styling the host element
 
@@ -72,9 +72,9 @@ The `:host-context(<selector>)` functional pseudo-class matches the host element
 
 ### Styling Shadow DOM markup from inside
 
-Shadow DOM features scoped styling: styles defined inside the scope of the shadow tree don't leak into the document DOM, and document styles don't leak into the shadow DOM. 
+Shadow DOM features scoped styling: styles defined inside the scope of the shadow tree don't leak into the main document's DOM (AKA Light DOM), and document styles don't leak into the Shadow DOM.
 
-Unfortunately, emulating scoped styling is near-to-impossible: the polyfill transforms these styles by prepending selectors with the element tag name, but this does not enforce lower bound encapsulation. Keep that in mind when authoring your elements (more on this later).
+Unfortunately, truly emulating scoped styling is near-to-impossible: the polyfill transforms these styles by prepending selectors with the element tag name, but this does not enforce [lower bound](https://github.com/webcomponents/webcomponentsjs/blob/master/src/ShadowCSS/ShadowCSS.js#L84-91) encapsulation. Keep this knowledge in the back of your mind when authoring your elements (more on this later).
 
 ``` html
 <element name="b-bar">
@@ -188,7 +188,7 @@ Second problem:
     <div id="three" class="foo">...</div>
 </b-bar>
 ```
-In this case, only the divs with a `foo` class will be distributed (`#one` and `#three`); the `::content div` selector should therefore match only these distributed nodes. Alas, as Bosonic will transpile this selector to `b-bar div`, `#two` will be styled too. To avoid this, you should use classes to distinguish between these divs:
+In this case, only the divs with a `foo` class will be distributed (`#one` and `#three`); the `::content div` selector should therefore match only these distributed nodes. Alas, as Bosonic will transpile this selector to `b-bar div`, `#two` will be styled too. To avoid this, you should use classes to distinguish between these HTML div elements:
 ``` css
 ::content div.foo {
     color: red;

--- a/src/doc/reference/shadow-dom.md
+++ b/src/doc/reference/shadow-dom.md
@@ -27,7 +27,7 @@ You can define __insertion points__ in your Shadow DOM with the `<content>` elem
     </script>
 </element>
 ```
-Here, we've defined 2 distribution points. As you can guess, the `select` attribute takes a CSS selector and is used to target a specific node in the Light DOM to be distributed at a specific point. The second `<content>` will simply distribute the rest of the Light DOM nodes at this insertion point.
+In this example, we've defined two distribution points. As you can probably guess, the `select` attribute takes a CSS selector and is used to target a specific node in the Light DOM to be distributed at a specific point. The second `<content>` will simply distribute the rest of the Light DOM nodes at this insertion point.
 
 If we put our element into use like this:
 ``` html

--- a/src/partials/_footer.ejs
+++ b/src/partials/_footer.ejs
@@ -1,6 +1,6 @@
 
     <footer>
-        <p>© 2014 Bosonic Authors. Code licensed under the <a href="https://github.com/bosonic/bosonic/blob/master/LICENSE">MIT License</a>. Documentation licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</p>
+        <p>© 2015 Bosonic Authors. Code licensed under the <a href="https://github.com/bosonic/bosonic/blob/master/LICENSE">MIT License</a>. Documentation licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</p>
     </footer>
 
     <!--<a href="https://github.com/bosonic/bosonic" target="_blank" class="forkme"><img style="position: fixed; top: 0; right: 0; border: 0; z-index:2" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>-->


### PR DESCRIPTION
* Updated footer copyright info
* Added links to content
* Updated grammar & spelling. 

### Notes
Consider making a full on tutorial or video series. Also at least more in depth - maybe a codepen.io embed. Also I am unsure if the spec will ultimately use `<element>` in the future. Should we have this if we are staying close to the current spec. The other thing is that once the Shadow DOM is updated to comply w/ v1 of the browser collective mind share, I would imagine the polyfill will change drastically and the way we use slots & distributed nodes may change. Should we create a feature branch or a separate fork/repo for changes & updates to this?

